### PR TITLE
We need to change the Result enum to be named E<ServiceName>Result in the proto definition

### DIFF
--- a/proto/cacheclient.proto
+++ b/proto/cacheclient.proto
@@ -6,7 +6,7 @@ option java_package = "grpc.cache_client";
 package cache_client;
 
 
-enum Result {
+enum ECacheResult {
   Internal_Server_Error = 0;
   Ok = 1;
   Hit = 2;
@@ -28,7 +28,7 @@ message GetRequest {
 }
 
 message GetResponse {
-  Result result = 1;
+  ECacheResult result = 1;
   bytes cache_body = 2;
   string message = 3;
 }
@@ -40,6 +40,6 @@ message SetRequest {
 }
 
 message SetResponse {
-  Result result = 1;
+  ECacheResult result = 1;
   string message = 2;
 }

--- a/proto/controlclient.proto
+++ b/proto/controlclient.proto
@@ -5,7 +5,7 @@ option java_package = "grpc.control_client";
 
 package control_client;
 
-enum Result {
+enum EControlResult {
   Internal_Server_Error = 0;
   Ok = 1;
   Service_Unavailable = 2;
@@ -20,5 +20,5 @@ message CreateCacheRequest {
 }
 
 message CreateCacheResponse {
-  Result result = 1;
+  EControlResult result = 1;
 }


### PR DESCRIPTION
Result collides with other names in Rust and the Result field per service will collide too.  The other strategy of having one common Result file and using that across all services was discussed too but then that would mean that we need to update all the proto files when EResult is updated. Hence for now we will just keep the Result per service in its proto file.

I will own the changes of moving it out to the other repositories