### PR TITLE
Updating the control proto file to use cache name as a String and to not use our customer special error codes.

### DIFF
--- a/proto/controlclient.proto
+++ b/proto/controlclient.proto
@@ -5,20 +5,13 @@ option java_package = "grpc.control_client";
 
 package control_client;
 
-enum EControlResult {
-  Internal_Server_Error = 0;
-  Ok = 1;
-  Service_Unavailable = 2;
-}
-
 service ScsControl {
   rpc CreateCache (CreateCacheRequest) returns (CreateCacheResponse) {}
 }
 
 message CreateCacheRequest {
-  bytes cache_name = 1;
+  string cache_name = 1;
 }
 
 message CreateCacheResponse {
-  EControlResult result = 1;
 }


### PR DESCRIPTION
We are modifying the protos  for control plane to not use an EControlResult. . We will return errors using the [existing io.grpc.Status.Code ](https://grpc.github.io/grpc-java/javadoc/io/grpc/Status.Code.html)