### PR TITLE
chore: Remove ECacheResult values that unnecessarily duplicate GRPC status

### DIFF
--- a/proto/cacheclient.proto
+++ b/proto/cacheclient.proto
@@ -7,13 +7,12 @@ package cache_client;
 
 
 enum ECacheResult {
-  Internal_Server_Error = 0;
+  Invalid = 0;
   Ok = 1;
   Hit = 2;
   Miss = 3;
-  Bad_Request = 4;
-  Unauthorized = 5;
-  Service_Unavailable = 6;
+
+  reserved 4 to 6;
 }
 
 


### PR DESCRIPTION
Communicate error statuses via the framework's provided means.
We have to handle those statuses anyway, so this simplifies the
error handling for clients and helps them leverage more grpc
machinations for free.