### PR TITLE
feat: add ListCaches proto

### DIFF
--- a/proto/controlclient.proto
+++ b/proto/controlclient.proto
@@ -8,6 +8,7 @@ package control_client;
 service ScsControl {
   rpc CreateCache (CreateCacheRequest) returns (CreateCacheResponse) {}
   rpc DeleteCache (DeleteCacheRequest) returns (DeleteCacheResponse) {}
+  rpc ListCaches (ListCachesRequest) returns (ListCachesResponse) {}
 }
 
 message DeleteCacheRequest {
@@ -22,4 +23,17 @@ message CreateCacheRequest {
 }
 
 message CreateCacheResponse {
+}
+
+message ListCachesRequest {
+  string next_token = 1;
+}
+
+message Cache {
+  string cache_name = 1;
+}
+
+message ListCachesResponse {
+  repeated Cache cache = 1;
+  string next_token = 2;
 }


### PR DESCRIPTION
Per our offline discussion, we will expose ListCaches as a vanilla
list Operation with pagination tokens. The backend rpc to CacheAdmin
will utilize grpc streaming however.

For our first cut, we will just dump the whole list of Caches (up to 100)
into the response and return null for next_token
