### PR TITLE
feat: Add _ to wire types for disambiguation with SDK Types

### DIFF
--- a/proto/cacheclient.proto
+++ b/proto/cacheclient.proto
@@ -17,28 +17,28 @@ enum ECacheResult {
 
 
 service Scs {
-  rpc Get (GetRequest) returns (GetResponse) {}
-  rpc Set (SetRequest) returns (SetResponse) {}
+  rpc Get (_GetRequest) returns (_GetResponse) {}
+  rpc Set (_SetRequest) returns (_SetResponse) {}
 }
 
 
-message GetRequest {
+message _GetRequest {
   bytes cache_key = 1;
 }
 
-message GetResponse {
+message _GetResponse {
   ECacheResult result = 1;
   bytes cache_body = 2;
   string message = 3;
 }
 
-message SetRequest {
+message _SetRequest {
   bytes cache_key = 1;
   bytes cache_body = 2;
   uint32 ttl_milliseconds = 3;
 }
 
-message SetResponse {
+message _SetResponse {
   ECacheResult result = 1;
   string message = 2;
 }

--- a/proto/controlclient.proto
+++ b/proto/controlclient.proto
@@ -6,34 +6,34 @@ option java_package = "grpc.control_client";
 package control_client;
 
 service ScsControl {
-  rpc CreateCache (CreateCacheRequest) returns (CreateCacheResponse) {}
-  rpc DeleteCache (DeleteCacheRequest) returns (DeleteCacheResponse) {}
-  rpc ListCaches (ListCachesRequest) returns (ListCachesResponse) {}
+  rpc CreateCache (_CreateCacheRequest) returns (_CreateCacheResponse) {}
+  rpc DeleteCache (_DeleteCacheRequest) returns (_DeleteCacheResponse) {}
+  rpc ListCaches (_ListCachesRequest) returns (_ListCachesResponse) {}
 }
 
-message DeleteCacheRequest {
+message _DeleteCacheRequest {
   string cache_name = 1;
 }
 
-message DeleteCacheResponse {
+message _DeleteCacheResponse {
 }
 
-message CreateCacheRequest {
+message _CreateCacheRequest {
   string cache_name = 1;
 }
 
-message CreateCacheResponse {
+message _CreateCacheResponse {
 }
 
-message ListCachesRequest {
+message _ListCachesRequest {
   string next_token = 1;
 }
 
-message Cache {
+message _Cache {
   string cache_name = 1;
 }
 
-message ListCachesResponse {
-  repeated Cache cache = 1;
+message _ListCachesResponse {
+  repeated _Cache cache = 1;
   string next_token = 2;
 }


### PR DESCRIPTION
Some of our SDK response/request objects share the same name as wire types. Hence when customers try to import these classes the autocomplete shows multiple options and it may be confusing for customers to choose the correct name.

As a way to establish this pattern, I am proposing that all wire types should just be declared with `_` names. It will prevent future confusion as we add new messages as to why some messages have _ while other don't

From:
https://www.notion.so/momentohq/Request-Response-SDK-Names-6480de775fe84298aaa15eb91315d208