### PR TITLE
chore: Update secret variable name for PyPI auth token

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -135,7 +135,7 @@ jobs:
           set -e
           set -x
           pushd python
-            ./pypi_setup.sh __token__ ${{ secrets.PYPI_AUTH_TOKEN }} >> ~/.pypirc
+            ./pypi_setup.sh __token__ ${{ secrets.CLIENT_PROTO_PYPI_TOKEN }} >> ~/.pypirc
           popd
         shell: bash
 


### PR DESCRIPTION
With @eaddingtonwhite help, moved the PyPI auth token to the org level secret.
Since secret names need to be unique at the org level, this repo's secret name got updated to `CLIENT_PROTO_PYPI_TOKEN`.