### PR TITLE
chore: Publish package to npm with a new scope name `@gomomento/generated-types`

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v1
         with:
-          node-version: 14
+          node-version: 16
 
       - name: Install protoc
         run: ./install_protoc.sh

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v1
         with:
-          node-version: "16"
+          node-version: 16
           registry-url: "https://registry.npmjs.org"
 
       - name: Install protoc
@@ -67,7 +67,7 @@ jobs:
           popd
         shell: bash
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
 
   publish_kotlin:
     runs-on: ubuntu-latest

--- a/javascript/package-lock.json
+++ b/javascript/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@momentohq/generated-types",
+  "name": "@gomomento/generated-types",
   "version": "0.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "@momentohq/generated-types",
+      "name": "@gomomento/generated-types",
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {

--- a/javascript/package.json
+++ b/javascript/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@momentohq/generated-types",
+  "name": "@gomomento/generated-types",
   "description": "Types for Momento services",
   "version": "0.0.1",
   "main": "index.js",


### PR DESCRIPTION
Due to the sign in issue mentioned [here](https://gomomento.slack.com/archives/C01AC7JT370/p1648234227968489), publishing the package with `@gomomento/generated-types`.
Naming discussion happened [here](https://gomomento.slack.com/archives/C037XLHFC79/p1648244643528289).
