### PR TITLE
feat: use a single jwk to encapsulate key id and algo along with the key

### DIFF
--- a/proto/controlclient.proto
+++ b/proto/controlclient.proto
@@ -45,9 +45,8 @@ message _CreateSigningKeyRequest {
 }
 
 message _CreateSigningKeyResponse {
-  string key_id = 1;
-  bytes private_key = 2;
-  uint64 expires_at = 3;
+  string key = 1;
+  uint64 expires_at = 2;
 }
 
 message _RevokeSigningKeyRequest {


### PR DESCRIPTION
In the create signing key response, we also need to include algo for our sdk to be able to use the key.  Instead of returning separate fields, we'll be using jwk(JOSN web key), which is a json data structure that represents a cryptographic key. 
https://datatracker.ietf.org/doc/html/rfc7517#section-1.1

Note that expiry is not a supported parameter in jwk.  We'll be returning this field separately. 