### PR TITLE
chore: also update the HttpSetRequest to use uint64

### DIFF
--- a/proto/httpcache.proto
+++ b/proto/httpcache.proto
@@ -18,7 +18,7 @@ message _HttpGetRequest {
 message _HttpSetRequest {
   string cache_name = 1;
   string cache_key = 2;
-  uint32 ttl_milliseconds = 3;
+  uint64 ttl_milliseconds = 3;
   string token = 4;
   bytes cache_body = 5;
 }


### PR DESCRIPTION
Looks like we also need to change this type to `uint64` so that our HttpClient is also compatible
