### PR TITLE
[DO NOT MERGE] chore: make compatible with .NET Framework 4.5.2

### DIFF
--- a/csharp/Momento.csproj
+++ b/csharp/Momento.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
   </PropertyGroup>
 
 <ItemGroup>
@@ -14,7 +15,7 @@
     <None Remove="Google.Protobuf" />
     <None Remove="Grpc.Tools" />
     <None Remove="src\" />
-    <None Remove="Grpc.Net.Client" />
+    <None Remove="Grpc.Core" />
     <None Remove="Grpc" />
   </ItemGroup>
   <ItemGroup>
@@ -23,10 +24,11 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Grpc.Net.Client" Version="2.40.0" />
+    <PackageReference Include="Grpc.Core" Version="2.45.0" />
     <PackageReference Include="Grpc" Version="2.41.1" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="src\" />
   </ItemGroup>
 </Project>
+


### PR DESCRIPTION
We don't want to merge this pr since we want to have a separate branch `clientProtosDotNetFramework4.5.2` for older .NET Frameworks without affecting users with more recent .NET Frameworks/Cores.
Relevant conversations: https://github.com/momentohq/client-sdk-csharp/pull/49
Relevant ticket: https://github.com/momentohq/client-sdk-csharp/issues/48

- Use `Grpc.Core` instead of `Grpc.Net.Client` to support .NET Framework 4.5.2
- I think we need to manually generate files from the proto in a Windows Server 2012 R2 instance and upload it to the artifactory since Windows Server 2022/2019 are the only GitHub-Hosted runners which don't support .NET Framework less than 4.7.2/4.8.
https://github.com/actions/virtual-environments/blob/main/images/win/Windows2022-Readme.md#net-framework
https://github.com/actions/virtual-environments/blob/main/images/win/Windows2019-Readme.md#net-framework

Closes #47 