### PR TITLE
feat: Add proto declarations for dictionary.

### DIFF
--- a/proto/cacheclient.proto
+++ b/proto/cacheclient.proto
@@ -20,9 +20,9 @@ service Scs {
   rpc Get (_GetRequest) returns (_GetResponse) {}
   rpc Set (_SetRequest) returns (_SetResponse) {}
   rpc Delete (_DeleteRequest) returns (_DeleteResponse) {}
-  rpc HashGet (_HashGetRequest) returns (_HashGetResponse) {}
-  rpc HashGetAll (_HashGetAllRequest) returns (_HashGetAllResponse) {}
-  rpc HashSet (_HashSetRequest) returns (_HashSetResponse) {}
+  rpc DictGet (_DictGetRequest) returns (_DictGetResponse) {}
+  rpc DictGetAll (_DictGetAllRequest) returns (_DictGetAllResponse) {}
+  rpc DictSet (_DictSetRequest) returns (_DictSetResponse) {}
 }
 
 message _GetRequest {
@@ -52,38 +52,38 @@ message _SetResponse {
   string message = 2;
 }
 
-message _HashGetRequest {
-  bytes cache_hash_name = 1;
-  bytes cache_hash_key = 2;
+message _DictGetRequest {
+  bytes dict_name = 1;
+  bytes dict_key = 2;
 }
 
-message _HashGetResponse {
+message _DictGetResponse {
   ECacheResult result = 1;
   bytes cache_body = 2;
   string message = 3;
 }
 
-message _HashGetAllRequest {
-  bytes cache_hash_name = 1;
+message _DictGetAllRequest {
+  bytes dict_name = 1;
 }
 
-message HashKeyValuePair {
+message DictKeyValuePair {
   bytes key = 1;
   bytes value = 2;
 }
 
-message _HashGetAllResponse {
+message _DictGetAllResponse {
   ECacheResult result = 1;
-  repeated HashKeyValuePair cache_body = 2;
+  repeated DictKeyValuePair dict_body = 2;
   string message = 3;
 }
 
-message _HashSetRequest {
-  bytes cache_hash_name = 1;
-  repeated HashKeyValuePair mapping = 2;
+message _DictSetRequest {
+  bytes dict_name = 1;
+  repeated DictKeyValuePair dict_body = 2;
 }
 
-message _HashSetResponse {
+message _DictSetResponse {
   ECacheResult result = 1;
   string message = 2;
 }

--- a/proto/cacheclient.proto
+++ b/proto/cacheclient.proto
@@ -67,15 +67,20 @@ message _HashGetAllRequest {
   bytes cache_hash_name = 1;
 }
 
+message HashKeyValuePair {
+  bytes key = 1;
+  bytes value = 2;
+}
+
 message _HashGetAllResponse {
   ECacheResult result = 1;
-  map<bytes, bytes> cache_body = 2;
+  repeated HashKeyValuePair cache_body = 2;
   string message = 3;
 }
 
 message _HashSetRequest {
   bytes cache_hash_name = 1;
-  map<bytes, bytes> mapping = 2;
+  repeated HashKeyValuePair mapping = 2;
 }
 
 message _HashSetResponse {

--- a/proto/cacheclient.proto
+++ b/proto/cacheclient.proto
@@ -20,9 +20,9 @@ service Scs {
   rpc Get (_GetRequest) returns (_GetResponse) {}
   rpc Set (_SetRequest) returns (_SetResponse) {}
   rpc Delete (_DeleteRequest) returns (_DeleteResponse) {}
-  rpc DictGet (_DictGetRequest) returns (_DictGetResponse) {}
-  rpc DictGetAll (_DictGetAllRequest) returns (_DictGetAllResponse) {}
-  rpc DictSet (_DictSetRequest) returns (_DictSetResponse) {}
+  rpc DictionaryGet (_DictionaryGetRequest) returns (_DictionaryGetResponse) {}
+  rpc DictionaryGetAll (_DictionaryGetAllRequest) returns (_DictionaryGetAllResponse) {}
+  rpc DictionarySet (_DictionarySetRequest) returns (_DictionarySetResponse) {}
 }
 
 message _GetRequest {
@@ -52,38 +52,38 @@ message _SetResponse {
   string message = 2;
 }
 
-message _DictGetRequest {
-  bytes dict_name = 1;
-  bytes dict_key = 2;
+message _DictionaryGetRequest {
+  bytes dictionary_name = 1;
+  bytes dictionary_key = 2;
 }
 
-message _DictGetResponse {
+message _DictionaryGetResponse {
   ECacheResult result = 1;
   bytes cache_body = 2;
   string message = 3;
 }
 
-message _DictGetAllRequest {
-  bytes dict_name = 1;
+message _DictionaryGetAllRequest {
+  bytes dictionary_name = 1;
 }
 
-message DictKeyValuePair {
+message DictionaryKeyValuePair {
   bytes key = 1;
   bytes value = 2;
 }
 
-message _DictGetAllResponse {
+message _DictionaryGetAllResponse {
   ECacheResult result = 1;
-  repeated DictKeyValuePair dict_body = 2;
+  repeated DictionaryKeyValuePair dictionary_body = 2;
   string message = 3;
 }
 
-message _DictSetRequest {
-  bytes dict_name = 1;
-  repeated DictKeyValuePair dict_body = 2;
+message _DictionarySetRequest {
+  bytes dictionary_name = 1;
+  repeated DictionaryKeyValuePair dictionary_body = 2;
 }
 
-message _DictSetResponse {
+message _DictionarySetResponse {
   ECacheResult result = 1;
   string message = 2;
 }

--- a/proto/cacheclient.proto
+++ b/proto/cacheclient.proto
@@ -20,6 +20,9 @@ service Scs {
   rpc Get (_GetRequest) returns (_GetResponse) {}
   rpc Set (_SetRequest) returns (_SetResponse) {}
   rpc Delete (_DeleteRequest) returns (_DeleteResponse) {}
+  rpc HashGet (_HashGetRequest) returns (_HashGetResponse) {}
+  rpc HashGetAll (_HashGetAllRequest) returns (_HashGetAllResponse) {}
+  rpc HashSet (_HashSetRequest) returns (_HashSetResponse) {}
 }
 
 message _GetRequest {
@@ -45,6 +48,37 @@ message _SetRequest {
 }
 
 message _SetResponse {
+  ECacheResult result = 1;
+  string message = 2;
+}
+
+message _HashGetRequest {
+  bytes cache_hash_name = 1;
+  bytes cache_hash_key = 2;
+}
+
+message _HashGetResponse {
+  ECacheResult result = 1;
+  bytes cache_body = 2;
+  string message = 3;
+}
+
+message _HashGetAllRequest {
+  bytes cache_hash_name = 1;
+}
+
+message _HashGetAllResponse {
+  ECacheResult result = 1;
+  map<bytes, bytes> cache_body = 2;
+  string message = 3;
+}
+
+message _HashSetRequest {
+  bytes cache_hash_name = 1;
+  map<bytes, bytes> mapping = 2;
+}
+
+message _HashSetResponse {
   ECacheResult result = 1;
   string message = 2;
 }

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -11,4 +11,4 @@ path = "src/lib.rs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-protobuf = { version = "2", features = ["with-bytes"] }
+protobuf = { version = "3", features = ["with-bytes"] }


### PR DESCRIPTION
Closes #50 

Add the rpc method declarations for DictionaryGet, DictionaryGetAll DictionarySet and the associated request and response messages. Terminology:
- dict, dictionary: a data structure that supports key-based indexing
- dictionary name: the name of a dictionary stored in momento (ie the cache key for the dictionary)
- dictionary key: a key to index into a dictionary
- dictionary value: the value corresponding to a key in a particular dictionary (ie `dictionary_value = dictionary_name.get(dictionary_key)`)

The following summarizes the methods:

- DictionaryGet: request the dictionary value for the dictionary key `dictionary_key` from a dictionary `dictionary_name`. The response message is identical to that of `_GetResponse`
- DictionaryGetAll: request the entire dictionary `dictionary_name` from the cache. The response message is parallel to `_DictionaryGetResponse` except the value to return is a list `DictionaryKeyValuePair`*.
- DictionarySet: upsert a dictionary `dictionary_name` with the keys and values from `dictionary_body`*. Consistent with the rest of the API, keys and values are bytes. The response message is identical to that of `_SetResponse`.

* Note protobuf does have a `map` type, which would be helpful here. Unfortunately it does not permit bytes as keys or values. Hence to represent `map<bytes, bytes>`, we use a repetition of `DictionaryKeyValuePair` messages, each of which defines a `key` (`bytes`), and `value` (`bytes`).