### PR TITLE
chore: add validity time to logged in message

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -167,6 +167,7 @@ jobs:
           set -x
           export PATH=`pwd`/protoc/bin/:$HOME/.cargo/bin:$PATH
           pushd rust
-            cargo publish --verbose --allow-dirty --dry-run
+            # We --no-verify because we have build.rs editing src instead of $BUILD_OUT :-(
+            cargo publish --verbose --allow-dirty --dry-run --no-verify
           popd
         shell: bash

--- a/proto/auth.proto
+++ b/proto/auth.proto
@@ -23,6 +23,15 @@ message _LoginResponse {
   // Terminal state, login success
   message LoggedIn {
     string session_token = 1;
+
+    // How many the token was valid for when issued.
+    // Will vary slightly from reality upon receipt, as
+    // time has passed since the token was minted.
+    // You might expect to see this true to within 10
+    // seconds of client-side timekeeping but as is
+    // ever the case, there are no guarantees with
+    // public network timing.
+    uint32 valid_for_seconds = 2;
   }
 
   // Terminal state, login error

--- a/proto/auth.proto
+++ b/proto/auth.proto
@@ -24,7 +24,7 @@ message _LoginResponse {
   message LoggedIn {
     string session_token = 1;
 
-    // How many the token was valid for when issued.
+    // How many seconds the token was valid for when issued.
     // Will vary slightly from reality upon receipt, as
     // time has passed since the token was minted.
     // You might expect to see this true to within 10


### PR DESCRIPTION
Will enable some more convenient client-side heuristics around
session refreshing.
