### PR TITLE
feat: Support variadic keys in DictionaryGet

### DIFF
--- a/proto/cacheclient.proto
+++ b/proto/cacheclient.proto
@@ -54,33 +54,36 @@ message _SetResponse {
 
 message _DictionaryGetRequest {
   bytes dictionary_name = 1;
-  bytes dictionary_key = 2;
+  repeated bytes dictionary_keys = 2;
 }
 
 message _DictionaryGetResponse {
-  ECacheResult result = 1;
-  bytes cache_body = 2;
-  string message = 3;
+  message _DictionaryGetResponsePart {
+    ECacheResult result = 1;
+    bytes cache_body = 2;
+  }
+  repeated _DictionaryGetResponsePart dictionary_body = 1;
+  string message = 2;
 }
 
 message _DictionaryGetAllRequest {
   bytes dictionary_name = 1;
 }
 
-message DictionaryKeyValuePair {
+message _DictionaryKeyValuePair {
   bytes key = 1;
   bytes value = 2;
 }
 
 message _DictionaryGetAllResponse {
   ECacheResult result = 1;
-  repeated DictionaryKeyValuePair dictionary_body = 2;
+  repeated _DictionaryKeyValuePair dictionary_body = 2;
   string message = 3;
 }
 
 message _DictionarySetRequest {
   bytes dictionary_name = 1;
-  repeated DictionaryKeyValuePair dictionary_body = 2;
+  repeated _DictionaryKeyValuePair dictionary_body = 2;
 }
 
 message _DictionarySetResponse {


### PR DESCRIPTION
Change DictionaryGetRequest to support any number of keys in the
request. Similarly modify DictionaryGetResponse to return multiple
values, each with the cache status (HIT, MISS, etc) and cache body.