### PR TITLE
feat: Add TTL & refresh TTL fields to _DictionarySetRequest message.

### DIFF
--- a/proto/cacheclient.proto
+++ b/proto/cacheclient.proto
@@ -84,6 +84,8 @@ message _DictionaryGetAllResponse {
 message _DictionarySetRequest {
   bytes dictionary_name = 1;
   repeated _DictionaryKeyValuePair dictionary_body = 2;
+  uint64 ttl_milliseconds = 3;
+  bool refresh_ttl = 4;
 }
 
 message _DictionarySetResponse {


### PR DESCRIPTION
Per discussions, data structure `set` operations will always include a
TTL and a flag to refresh the TTL (or not).

We include the TTL to be consistent with our system design: all items
in the cache must have a TTL.

Because users may want different behavior when creating a data
structure vs updating a data structure, we also include the flag
`refresh_ttl`. The intention is that when a user creates a data structure,
`ttl_milliseconds` is applied. When a user updates a data structure,
if the flag `refresh_ttl` is `true`, then the TTL will be refreshed to
`ttl_milliseconds`. Otherwise when `refresh_ttl` is `false` on an
update, the remaining TTL will be left as-is.