### PR TITLE
fix: take a single value as input for list push apis

### DIFF
--- a/proto/cacheclient.proto
+++ b/proto/cacheclient.proto
@@ -204,7 +204,7 @@ message _SetDifferenceResponse {
 // stored = request + stored
 message _ListPushFrontRequest {
   bytes list_name = 1;
-  repeated bytes values = 2;
+  bytes value = 2;
   uint64 ttl_milliseconds = 3;
   bool refresh_ttl = 4;
 }
@@ -214,7 +214,7 @@ message _ListPushFrontResponse {}
 // stored = stored + request
 message _ListPushBackRequest {
   bytes list_name = 1;
-  repeated bytes values = 2;
+  bytes value = 2;
   uint64 ttl_milliseconds = 3;
   bool refresh_ttl = 4;
 }


### PR DESCRIPTION
As per our discussion this morning, we want the push/pop operations to operate on a single value rather than multiple values. We already do that for the list pop apis. This PR updates the `ListPushFront` and `ListPushBack` api requests to take a single value as an input.