### PR TITLE
feat: add truncate option to list push

### DIFF
--- a/proto/cacheclient.proto
+++ b/proto/cacheclient.proto
@@ -209,7 +209,7 @@ message _ListPushFrontRequest {
   bool refresh_ttl = 4;
 
   // ensure total length <= this; remove excess from back of list
-  optional uint64 truncate_tail_to_size = 5;
+  optional uint32 truncate_tail_to_size = 5;
 }
 
 message _ListPushFrontResponse {}
@@ -222,7 +222,7 @@ message _ListPushBackRequest {
   bool refresh_ttl = 4;
 
   // ensure total length <= this; remove excess from front of list
-  optional uint64 truncate_head_to_size = 5;
+  optional uint32 truncate_head_to_size = 5;
 }
 
 message _ListPushBackResponse {}

--- a/proto/cacheclient.proto
+++ b/proto/cacheclient.proto
@@ -207,6 +207,9 @@ message _ListPushFrontRequest {
   bytes value = 2;
   uint64 ttl_milliseconds = 3;
   bool refresh_ttl = 4;
+
+  // ensure total length <= this; remove excess from back of list
+  optional uint64 truncate_tail_to_size = 5;
 }
 
 message _ListPushFrontResponse {}
@@ -217,6 +220,9 @@ message _ListPushBackRequest {
   bytes value = 2;
   uint64 ttl_milliseconds = 3;
   bool refresh_ttl = 4;
+
+  // ensure total length <= this; remove excess from front of list
+  optional uint64 truncate_head_to_size = 5;
 }
 
 message _ListPushBackResponse {}


### PR DESCRIPTION
This adds an optional parameter to `ListPushFront` and `ListPushBack`
requests to maintain a list length invariant. Should the push
operation make the list exceed the given length, the excess is trimmed
from the opposite end of the list.

Closes #81 