### PR TITLE
fix: only generate gRPC client code for C#

### DIFF
--- a/csharp/Momento.Protos.csproj
+++ b/csharp/Momento.Protos.csproj
@@ -16,8 +16,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Protobuf Include="../proto/cacheclient.proto" />
-    <Protobuf Include="../proto/controlclient.proto" />
+    <Protobuf Include="../proto/cacheclient.proto" GrpcServices="Client" />
+    <Protobuf Include="../proto/controlclient.proto" GrpcServices="Client" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
The C# generator allows the option to generate client code vs server
code vs both. By default it generates both. Since the clients only
need the client code, this change narrows the build to only generate
those.