### PR TITLE
fix: make truncate_*_to_size nomenclature consistent with ListPush*

### DIFF
--- a/proto/cacheclient.proto
+++ b/proto/cacheclient.proto
@@ -209,7 +209,7 @@ message _ListPushFrontRequest {
   bool refresh_ttl = 4;
 
   // ensure total length <= this; remove excess from back of list
-  optional uint32 truncate_tail_to_size = 5;
+  optional uint32 truncate_back_to_size = 5;
 }
 
 message _ListPushFrontResponse {}
@@ -222,7 +222,7 @@ message _ListPushBackRequest {
   bool refresh_ttl = 4;
 
   // ensure total length <= this; remove excess from front of list
-  optional uint32 truncate_head_to_size = 5;
+  optional uint32 truncate_front_to_size = 5;
 }
 
 message _ListPushBackResponse {}


### PR DESCRIPTION
For `ListPush` We use the nouns "Front" and "Back" to refer to the
beginning and end of the list respectively. In the previous commit, in
the context of truncate, we used the nouns "Head" and "Tail". That
introduced extra vocabulary to refer to exactly the same
concepts. This commit renames "Head" and "Tail" to "Front" and "Back"
for consistency.