### PR TITLE
feat: add `DictionaryIncrement`

### DIFF
--- a/proto/cacheclient.proto
+++ b/proto/cacheclient.proto
@@ -16,6 +16,10 @@ enum ECacheResult {
   reserved 4 to 6;
 }
 
+enum ECacheIncrementResult {
+  Ok = 1;
+  ParseError = 2;
+}
 
 service Scs {
   rpc Get (_GetRequest) returns (_GetResponse) {}
@@ -25,6 +29,7 @@ service Scs {
   rpc DictionaryGet (_DictionaryGetRequest) returns (_DictionaryGetResponse) {}
   rpc DictionaryFetch (_DictionaryFetchRequest) returns (_DictionaryFetchResponse) {}
   rpc DictionarySet (_DictionarySetRequest) returns (_DictionarySetResponse) {}
+  rpc DictionaryIncrement (_DictionaryIncrementRequest) returns (_DictionaryIncrementResponse) {}
   rpc DictionaryDelete (_DictionaryDeleteRequest) returns (_DictionaryDeleteResponse) {}
   
   rpc SetFetch (_SetFetchRequest) returns (_SetFetchResponse) {}
@@ -121,6 +126,19 @@ message _DictionarySetRequest {
 }
 
 message _DictionarySetResponse {}
+
+message _DictionaryIncrementRequest {
+  bytes dictionary_name = 1;
+  bytes field = 2;
+  int64 amount = 3;
+  uint64 ttl_milliseconds = 4;
+  bool refresh_ttl = 5;
+}
+
+message _DictionaryIncrementResponse {
+  ECacheIncrementResult status = 1;
+  int64 value = 2;
+}
 
 message _DictionaryDeleteRequest {
   message Some {

--- a/proto/cacheclient.proto
+++ b/proto/cacheclient.proto
@@ -17,8 +17,8 @@ enum ECacheResult {
 }
 
 enum ECacheIncrementResult {
-  Ok = 1;
-  ParseError = 2;
+  IncrementOk = 0;
+  IncrementParseError = 1;
 }
 
 service Scs {


### PR DESCRIPTION
This adds the RPC, request, and response messages for `DictionaryIncrement`. The response includes a `status` field to indicate whether the operation was successful or not.

An increment operation (`DictionaryIncrement` or regular `Increment`) may fail if the stored value does not parse to a number. Other errors to consider including are integer overflow or integer underflow.