### PR TITLE
fix: update grpc versions to match what we have in kitchensink

### DIFF
--- a/kotlin-messages/kotlin/messages/build.gradle.kts
+++ b/kotlin-messages/kotlin/messages/build.gradle.kts
@@ -12,9 +12,9 @@ plugins {
     idea
 }
 
-val grpcKotlinVersion = "1.1.0"
-val grpcProtobufVersion = "3.17.3"
-val grpcVersion = "1.39.0"
+val grpcKotlinVersion = "1.3.0"
+val grpcProtobufVersion = "3.21.2"
+val grpcVersion = "1.47.0"
 
 dependencies {
     implementation(kotlin("stdlib"))


### PR DESCRIPTION
Our shared libraries are using newer versions of grpc than what our client_protos were using. This was causing some conflicting jars to be pulled, preventing us from being able to send metrics from our canaries. This pr addresses this by aligning the versions of grpc with what we have inside of kitchensink