### PR TITLE
feat: update function* protos for Config / Invoke / Delete

### DIFF
--- a/proto/function.proto
+++ b/proto/function.proto
@@ -14,6 +14,7 @@ service FunctionRegistry {
   // Register a new Function. This will overwrite any existing Function with the same name.
   // Functions are registered within a cache, which namespaces them.
   rpc PutFunction(_PutFunctionRequest) returns (_PutFunctionResponse) {}
+  rpc PutFunctionConfig(_PutFunctionConfigRequest) returns (_PutFunctionConfigResponse) {}
   rpc PutWasm(_PutWasmRequest) returns (_PutWasmResponse) {}
   rpc ListFunctions(_ListFunctionsRequest) returns (stream function_types._Function) {}
   rpc ListFunctionVersions(_ListFunctionVersionsRequest) returns (stream function_types._FunctionVersion) {}
@@ -40,6 +41,20 @@ message _PutFunctionRequest {
 }
 
 message _PutFunctionResponse {
+  function_types._Function function = 1;
+}
+
+message _PutFunctionConfigRequest {
+  // The function to update
+  oneof function_specifier {
+    function_types._FunctionKey function_key = 1;
+    string                      function_id  = 2;
+  }
+  // Updates the current function version
+  optional function_types._CurrentFunctionVersion new_version = 3;
+}
+
+message _PutFunctionConfigResponse {
   function_types._Function function = 1;
 }
 

--- a/proto/function.proto
+++ b/proto/function.proto
@@ -19,8 +19,8 @@ service FunctionRegistry {
   rpc ListFunctions(_ListFunctionsRequest) returns (stream function_types._Function) {}
   rpc ListFunctionVersions(_ListFunctionVersionsRequest) returns (stream function_types._FunctionVersion) {}
   rpc ListWasms(_ListWasmsRequest) returns (stream function_types._Wasm) {}
-
-  // List and delete rpcs are to be added later
+  rpc DeleteFunction(_DeleteFunctionRequest) returns (_DeleteFunctionResponse) {}
+  rpc DeleteWasm(_DeleteWasmRequest) returns (_DeleteWasmResponse) {}
 }
 
 service FunctionHost {
@@ -92,6 +92,27 @@ message _ListFunctionsRequest {
 message _ListFunctionVersionsRequest {
   // List the versions of a given function
   string function_id = 1;
+}
+
+message _DeleteFunctionRequest {
+  // The cache the function belongs to
+  string cache_name = 1;
+
+  // The name of the function
+  string name = 2;
+}
+
+message _DeleteFunctionResponse {
+
+}
+
+message _DeleteWasmRequest {
+  // The name of the wasm
+  string name = 1;
+}
+
+message _DeleteWasmResponse {
+
 }
 
 message _InvokeWebFunctionRequest {

--- a/proto/function.proto
+++ b/proto/function.proto
@@ -23,6 +23,10 @@ service FunctionRegistry {
   // List and delete rpcs are to be added later
 }
 
+service FunctionHost {
+  rpc InvokeWebFunction(_InvokeWebFunctionRequest) returns (_InvokeWebFunctionResponse) {}
+}
+
 message _PutFunctionRequest {
   // The cache within which the Function is stored.
   string cache_name = 1;
@@ -88,4 +92,18 @@ message _ListFunctionsRequest {
 message _ListFunctionVersionsRequest {
   // List the versions of a given function
   string function_id = 1;
+}
+
+message _InvokeWebFunctionRequest {
+  string              cache_name       = 1;
+  string              function_name    = 2;
+  map<string, string> request_headers  = 3;
+  bytes               request_body     = 4;
+  map<string, string> query_parameters = 5;
+}
+
+message _InvokeWebFunctionResponse {
+  uint32              status           = 1;
+  map<string, string> response_headers = 2;
+  bytes               response_body    = 3;
 }

--- a/proto/function_types.proto
+++ b/proto/function_types.proto
@@ -19,11 +19,13 @@ message _Function {
   // What is the actual latest version of the function?
   uint32 latest_version = 5;
 
-  // How many concurrent invocations are allowed for this function
+  // TODO: deprecate this when we have fully migrated to the _FunctionLimits type
   uint32 concurrency_limit = 6;
 
   // Human-readable datetime string in UTC format
   string last_updated_at = 7;
+
+  _FunctionLimits function_limits = 8;
 }
 
 message _CurrentFunctionVersion {
@@ -81,9 +83,24 @@ message _FunctionId {
   uint32 version = 2;
 }
 
+// Customer-friendly alternative to `string function_id` (NOT `_FunctionId function_version_id`)
+message _FunctionKey {
+  // The name of the cache the function belongs to
+  string cache_name = 1;
+  // The name of the function
+  string name = 2;
+}
+
 message _WasmId {
   // Globally unique id, this is stable across versions of the wasm.
   string id = 1;
   // A sub-id of sorts. Together with the id, this is a unique identifier for a wasm binary.
   uint32 version = 2;
+}
+
+message _FunctionLimits {
+  // How many concurrent executions of this function are allowed
+  uint32 concurrency_limit = 1;
+  // Maximum memory the function may consume, in bytes
+  uint64 memory_limit_bytes = 2;
 }


### PR DESCRIPTION
This PR updates `function.proto` and `function_types.proto`, which now allow customers to:
- Update a Momento Function's current function version
- Invoke a Function via GRPC (instead of HTTP/`reqwest`, currently available in the CLI)
- Delete a Function or WASM