### PR TITLE
feat: add description to `_FunctionVersion` proto

### DIFF
--- a/proto/function.proto
+++ b/proto/function.proto
@@ -32,7 +32,7 @@ message _PutFunctionRequest {
   string cache_name = 1;
   // Friendly name for the Function. This is used to call the Function, so call it what you want to use to call it.
   string name = 2;
-  // Optional description for the Function. You can use this to keep some notes about this Function.
+  // Optional description for this Function version. You can use this to keep some notes about the overall Function or this specific implementation.
   string description = 3;
   // The environment variables that are available to this function as virtual environment via the WASI interface.
   map<string, function_types._EnvironmentValue> environment = 4;

--- a/proto/function_types.proto
+++ b/proto/function_types.proto
@@ -10,7 +10,7 @@ message _Function {
   // The name of the function.
   string name = 2;
 
-  // A convenience for consoles.
+  // The description of the function. TODO: deprecate this when we have fully migrated to _FunctionVersion descriptions
   string description = 3;
 
   // What is the current version of the function set to use upon invocation?
@@ -44,6 +44,9 @@ message _CurrentFunctionVersion {
 message _FunctionVersion {
   // This unique identifier should change when a function's metadata is updated
   _FunctionId id = 1;
+
+  // The description of the function or this specific version/implementation
+  string description = 2;
 
   // The wasm ID this function uses
   _WasmId wasm_id = 20;


### PR DESCRIPTION
Prepares for migration from overall `Function` description to specific `FunctionVersion` descriptions, which can, for example, note the GitHub release associated with each function version and allow for quick selection for rollback / pinning.

(work towards https://github.com/momentohq/momento-cli/pull/371)